### PR TITLE
Upgrade to 1.0 and framework change to NetStandard 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ public class Startup
     {
       var slConfig = Configuration.GetSection("SyslogSettings");
       if (slConfig != null)
-        loggerFactory.AddSyslog(slConfig, Configuration.Get<string>("COMPUTERNAME", "localhost"));
+        loggerFactory.AddSyslog(slConfig, Configuration.GetValue<string>("COMPUTERNAME", "localhost"));
     }
   }
 }  

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview1-002702"
+    "version": "1.0.0-preview2-003121"
   }
 }

--- a/src/Syslog.Framework.Logging/project.json
+++ b/src/Syslog.Framework.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rc2-final-*",
+  "version": "1.0.0",
   "description": "ASP.NET 5 logging framework provider that enables an application to send log messages to a syslog server.",
   "authors": [ "mguinness" ],
   "packOptions": {
@@ -16,14 +16,14 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "System.Net.Sockets": "4.1.0-rc2-24027",
-        "System.Net.Primitives": "4.0.11-rc2-24027",
-        "System.Text.Encoding": "4.0.11-rc2-24027"
+        "System.Net.Sockets": "4.1.0",
+        "System.Net.Primitives": "4.0.11",
+        "System.Text.Encoding": "4.0.11"
       }
     }
   },
   "dependencies": {
-    "Microsoft.Extensions.Configuration.Binder": "1.0.0-rc2-final",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-final"
+    "Microsoft.Extensions.Configuration.Binder": "1.0.0",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0"
   }
 }

--- a/src/Syslog.Framework.Logging/project.json
+++ b/src/Syslog.Framework.Logging/project.json
@@ -9,7 +9,7 @@
   },
   "frameworks": {
     "net452": { },
-    "netcoreapp1.0": {
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -22,8 +22,9 @@
       }
     }
   },
-  "dependencies": {
-    "Microsoft.Extensions.Configuration.Binder": "1.0.0",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0"
-  }
+    "dependencies": {
+        "Microsoft.Extensions.Configuration.Binder": "1.0.0",
+        "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
+        "NETStandard.Library": "1.6.0"
+    }
 }


### PR DESCRIPTION
Found this project today while playing with docker and .NET Core on Linux. Very useful!
Had to upgrade packages to use it with RTM and as I think NetStandard 1.3 (the lowest .NetStandard with matching set of API) is slightly better choice, modified the framework section as well.
