### PR TITLE
Added support for RFC 5424 (new Syslog standard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,8 @@ using System;
 
 namespace MySyslogConsoleApp
 {
-
   class Program
   {
-
     public readonly static SyslogLoggerProvider mLoggingProvider;
     public readonly static ILogger mLogger;
 
@@ -93,15 +91,12 @@ namespace MySyslogConsoleApp
 
   public class MyAwesomeClass
   {
-  
     private static readonly ILogger mLogger = Program.mLoggingProvider.CreateLogger<MyAwesomeClass>();
     
     public void DoSomethingAmazing()
     {
       mLogger.LogCritical("I just did something awe inspiring!");
     }
-  
   }
-
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ Next in appsettings.json add the following and modify where necessary:
         "ServerPort": 514,
         "HeaderType": "Rfc5424v1",
         "FacilityType": "Local0",
-        "UseUtc": true
+        "UseUtc": true,
+        "StructuredData": [ 
+          {
+            "Id": "mydata",
+            "Elements": [
+              { "Name": "tag", "Value": "MyTag" }
+            ]
+          }
+        ]
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Syslog provider for [Microsoft.Extensions.Logging](https://www.nuget.org/package
 
 This package routes ASP.NET log messages through Syslog, so you can capture these in any Syslog server like [Syslog Server](https://github.com/mguinness/syslogserver).
 
+The Syslog implementation supports the following features:
+
+ - RFC 3164
+ - RFC 5424 (v1)
+ - Structure data (RFC 5424 only)
+ - UTC or local time stamps
+ - Custom facility types
+
 ### Instructions
 
 Install the Syslog.Framework.Logging [NuGet package](https://www.nuget.org/packages/Syslog.Framework.Logging).
@@ -12,23 +20,80 @@ Next in appsettings.json add the following and modify where necessary:
     {
       "SyslogSettings": {
         "ServerHost": "127.0.0.1",
-        "ServerPort": 514
+        "ServerPort": 514,
+        "HeaderType": "Rfc5424v1",
+        "FacilityType": "Local0",
+        "UseUtc": true
       }
     }
 
-Then in your application's `Configure` method in Startup, configure Syslog:
+Then in your web application's `Main` method, configure Syslog:
 
 ```csharp
-public class Startup
+public class Program
 {
-  public Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+  public static void Main(string[] args)
   {
-    if (env.IsDevelopment())
+    CreateWebHostBuilder(args)
+      .ConfigureLogging((ctx, logging) =>
+      {
+        var slConfig = ctx.Configuration.GetSection("SyslogSettings");
+        if (slConfig != null)
+        {
+          var settings = new SyslogLoggerSettings();
+          slConfig.Bind(settings);
+          // Configure structured data here if desired.
+          logging.AddSyslog(settings);
+        }
+      }
+  }
+}
+```
+
+If you have a console app, you can use the logging provider directly. This is what Microsoft uses to instantiate `ILogger` instances. It is possible to setup Microsoft dependency injection, but that is outside the scope of this article.
+
+```csharp
+using Microsoft.Extensions.Logging;
+using Syslog.Framework.Logging;
+using System;
+
+namespace MySyslogConsoleApp
+{
+
+  class Program
+  {
+
+    public readonly static SyslogLoggerProvider mLoggingProvider;
+    public readonly static ILogger mLogger;
+
+    static Program()
     {
-      var slConfig = Configuration.GetSection("SyslogSettings");
-      if (slConfig != null)
-        loggerFactory.AddSyslog(slConfig, Configuration.GetValue<string>("COMPUTERNAME", "localhost"));
+      var settings = new SyslogLoggerSettings();
+      // Set the Syslog setting here.
+      mLoggingProvider = new SyslogLoggerProvider(settings, Environment.MachineName, Microsoft.Extensions.Logging.LogLevel.Debug);
+      mLogger = mLoggingProvider.CreateLogger<Program>();
+    }
+
+    static void Main(string[] args)
+    {
+      mLogger.LogInformation("Hello World");
+      var awe = new MyAwesomeClass();
+      awe.DoSomethingAmazing();
+      Console.WriteLine("Hello World!");
     }
   }
-}  
+
+  public class MyAwesomeClass
+  {
+  
+    private static readonly ILogger mLogger = Program.mLoggingProvider.CreateLogger<MyAwesomeClass>();
+    
+    public void DoSomethingAmazing()
+    {
+      mLogger.LogCritical("I just did something awe inspiring!");
+    }
+  
+  }
+
+}
 ```

--- a/src/Syslog.Framework.Logging/Properties/AssemblyInfo.cs
+++ b/src/Syslog.Framework.Logging/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Syslog.Framework.Logging")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
+++ b/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
@@ -16,11 +16,10 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>3.0.0.5</Version>
+    <Version>2.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BizArk.Core" Version="3.1.0.19" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
   </ItemGroup>  

--- a/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
+++ b/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
@@ -16,12 +16,13 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.0.0</Version>
+    <Version>3.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="BizArk.Core" Version="3.1.0.19" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
   </ItemGroup>  
 
 </Project>

--- a/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
+++ b/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
@@ -16,7 +16,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>3.0.0.0</Version>
+    <Version>3.0.0.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
+++ b/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core logging framework provider that enables an application to send log messages to a syslog server.</Description>
-    <Authors>mguinness</Authors>
+    <Authors>mguinness, bbrewder</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Syslog.Framework.Logging</AssemblyName>
     <PackageId>Syslog.Framework.Logging</PackageId>

--- a/src/Syslog.Framework.Logging/SyslogEnums.cs
+++ b/src/Syslog.Framework.Logging/SyslogEnums.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Syslog.Framework.Logging
+{
+
+	/// <summary>
+	/// Different header formats that are available.
+	/// </summary>
+	public enum SyslogHeaderType
+	{
+		Rfc3164,
+		Rfc5424v1
+	}
+
+	/// <summary>
+	/// Available facility types. Same values for both RFC 3164 & 5424.
+	/// </summary>
+	public enum FacilityType
+	{
+		Kern = 0,
+		User = 1,
+		Mail = 2,
+		Daemon = 3,
+		Auth = 4,
+		Syslog = 5,
+		LPR = 6,
+		News = 7,
+		UUCP = 8,
+		Cron = 9,
+		AuthPriv = 10,
+		FTP = 11,
+		NTP = 12,
+		Audit = 13,
+		Audit2 = 14,
+		CRON2 = 15,
+		Local0 = 16,
+		Local1 = 17,
+		Local2 = 18,
+		Local3 = 19,
+		Local4 = 20,
+		Local5 = 21,
+		Local6 = 22,
+		Local7 = 23
+	}
+
+	internal enum SeverityType { Emergency, Alert, Critical, Error, Warning, Notice, Informational, Debug };
+
+}

--- a/src/Syslog.Framework.Logging/SyslogEnums.cs
+++ b/src/Syslog.Framework.Logging/SyslogEnums.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Syslog.Framework.Logging
+﻿namespace Syslog.Framework.Logging
 {
 
 	/// <summary>

--- a/src/Syslog.Framework.Logging/SyslogEnums.cs
+++ b/src/Syslog.Framework.Logging/SyslogEnums.cs
@@ -1,6 +1,5 @@
 ﻿namespace Syslog.Framework.Logging
 {
-
 	/// <summary>
 	/// Different header formats that are available.
 	/// </summary>
@@ -42,5 +41,4 @@
 	}
 
 	internal enum SeverityType { Emergency, Alert, Critical, Error, Warning, Notice, Informational, Debug };
-
 }

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -1,94 +1,210 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using BizArk.Core.Extensions.StringExt;
+using BizArk.Core.Util;
+using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 
 namespace Syslog.Framework.Logging
 {
-    public class SyslogLogger : ILogger
-    {
-        private readonly string _name;
-        private readonly string _host;
-        private readonly LogLevel _lvl;
-        private readonly SyslogLoggerSettings _settings;
+	public abstract class SyslogLogger : ILogger
+	{
+		private readonly string _name;
+		private readonly string _host;
+		private readonly LogLevel _lvl;
+		private readonly SyslogLoggerSettings _settings;
 
-        enum FacilityType
-        {
-            Kern, User, Mail, Daemon, Auth, Syslog, LPR, News, UUCP, Cron, AuthPriv, FTP,
-            NTP, Audit, Audit2, CRON2, Local0, Local1, Local2, Local3, Local4, Local5, Local6, Local7
-        };
+		public SyslogLogger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
+		{
+			_name = name;
+			_settings = settings;
+			_host = host;
+			_lvl = lvl;
+		}
 
-        enum SeverityType { Emergency, Alert, Critical, Error, Warning, Notice, Informational, Debug };
+		public IDisposable BeginScope<TState>(TState state)
+		{
+			return null;
+		}
 
-        public SyslogLogger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
-        {
-            _name = name;
-            _settings = settings;
-            _host = host;
-            _lvl = lvl;
-        }
+		public bool IsEnabled(LogLevel logLevel)
+		{
+			return logLevel != LogLevel.None && logLevel >= _lvl;
+		}
 
-        public IDisposable BeginScope<TState>(TState state)
-        {
-            return null;
-        }
+		public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+		{
+			if (formatter == null)
+				throw new ArgumentNullException(nameof(formatter));
 
-        public bool IsEnabled(LogLevel logLevel)
-        {
-            return logLevel != LogLevel.None && logLevel >= _lvl;
-        }
+			if (!IsEnabled(logLevel)) return;
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-        {
-            SeverityType severity = SeverityType.Debug;
+			string message = formatter(state, exception);
+			if (String.IsNullOrEmpty(message)) return;
 
-            if (IsEnabled(logLevel))
-            {
-                switch (logLevel)
-                {
-                    case LogLevel.Information:
-                        severity = SeverityType.Informational;
-                        break;
-                    case LogLevel.Warning:
-                        severity = SeverityType.Warning;
-                        break;
-                    case LogLevel.Error:
-                        severity = SeverityType.Error;
-                        break;
-                    case LogLevel.Critical:
-                        severity = SeverityType.Critical;
-                        break;
-                }
-            }
-            else
-                return;
+			// Defined in RFC 5424, section 6.2.1, and RFC 3164, section 4.1.1.
+			// If a different value is needed, then this code should probably move into the specific loggers.
+			var severity = MapToSeverityType(logLevel);
+			var priority = ((int)_settings.FacilityType * 8) + (int)severity; // (Facility * 8) + Severity = Priority
+			var procid = GetProcID();
+			var now = _settings.UseUtc ? DateTime.UtcNow : DateTime.Now;
+			var msg = FormatMessage(priority, now, _host, _name, procid, eventId.Id, message);
+			var raw = Encoding.ASCII.GetBytes(msg);
 
-            if (formatter == null)
-                throw new ArgumentNullException(nameof(formatter));
+			using (var udp = new UdpClient())
+			{
+				udp.Send(raw, raw.Length, _settings.ServerHost, _settings.ServerPort);
+			}
+		}
 
-            string message = formatter(state, exception);
+		protected abstract string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message);
 
-            if (!String.IsNullOrEmpty(message))
-            {
-                int priority = ((int)FacilityType.Local0 * 8) + (int)severity; // (Facility * 8) + Severity = Priority
-                string msg = String.Format("<{0}>{1:MMM dd HH:mm:ss} {2} {3}", priority, DateTime.Now, _host, _name + ": " + message); // RFC 3164 header format
+		private int? _procID;
+		private int GetProcID()
+		{
+			if (_procID == null)
+			{
+				try
+				{
+					// Attempt to get the process ID. This might not work on all platforms.
+					_procID = Process.GetCurrentProcess().Id;
+				}
+				catch
+				{
+					// If we can't get it, just default to 0.
+					_procID = 0;
+				}
+			}
 
-                UdpClient udp = new UdpClient();
-                byte[] raw = Encoding.ASCII.GetBytes(msg);
+			return _procID.Value;
+		}
 
-                try
-                {
-                    udp.SendAsync(raw, Math.Min(raw.Length, 1024), _settings.ServerHost, _settings.ServerPort);
-                }
-                finally
-                {
-#if NET452
-                    udp.Close();
-#else
-                    udp.Dispose();
-#endif
-                }
-            }
-        }
-    }
+		internal virtual SeverityType MapToSeverityType(LogLevel logLevel)
+		{
+			switch (logLevel)
+			{
+				case LogLevel.Information:
+					return SeverityType.Informational;
+				case LogLevel.Warning:
+					return SeverityType.Warning;
+				case LogLevel.Error:
+					return SeverityType.Error;
+				case LogLevel.Critical:
+					return SeverityType.Critical;
+				default:
+					return SeverityType.Debug;
+			}
+		}
+
+	}
+
+	/// <summary>
+	/// Based on RFC 3164: https://tools.ietf.org/html/rfc3164
+	/// </summary>
+	public class Syslog3164Logger : SyslogLogger
+	{
+
+		private readonly StringTemplate _tmpl = new StringTemplate("<{priority}>{now:MMM dd HH:mm:ss} {host} {tag} {message}");
+
+		public Syslog3164Logger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
+			: base(name, settings, host, lvl)
+		{
+		}
+
+		protected override string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message)
+		{
+			return _tmpl.Format(new
+			{
+				priority,
+				now,
+				host,
+				tag = name.Replace(".", "").Replace("_", "").Left(32), // Alphanumeric, Max length is 32 according to spec
+				message
+			});
+		}
+
+	}
+
+	/// <summary>
+	/// Based on RFC 5424: https://tools.ietf.org/html/rfc5424
+	/// </summary>
+	public class Syslog5424v1Logger : SyslogLogger
+	{
+		private readonly StringTemplate _tmpl = new StringTemplate("<{priority}>1 {now:yyyy-MM-ddTHH:mm:ss} {host} {name} {procid} {msgid}{data} {message}");
+		private readonly string _structuredData;
+
+		public Syslog5424v1Logger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
+			: base(name, settings, host, lvl)
+		{
+			_structuredData = FormatStructuredData(settings);
+		}
+
+		private string FormatStructuredData(SyslogLoggerSettings settings)
+		{
+			if (settings.StructuredData.Count == 0) return null;
+
+			var sb = new StringBuilder();
+			sb.Append(" "); // Need to add a space to separate what came before it.
+			foreach (var data in settings.StructuredData)
+			{
+				if (!IsValidPrintAscii(data.Id, '=', ' ', ']', '"'))
+					throw new InvalidOperationException($"ID for structured data {data.Id} is not valid. US Ascii 33-126 only, except '=', ' ', ']', '\"'");
+
+				sb.Append($"[{data.Id}");
+				foreach (var element in data.Elements)
+				{
+					if (!IsValidPrintAscii(element.Name, '=', ' ', ']', '"'))
+						throw new InvalidOperationException($"Element {element.Name} in structured data {data.Id} is not valid. US Ascii 33-126 only, except '=', ' ', ']', '\"'");
+
+					// According to spec, need to escape these characters.
+					var val = element.Value
+						.Replace("\\", "\\\\")
+						.Replace("\"", "\\\"")
+						.Replace("]", "\\]");
+					sb.Append($" {element.Name}=\"{val}\"");
+				}
+				sb.Append("]");
+			}
+
+			return sb.ToString();
+		}
+
+		/// <summary>
+		/// Based on spec, section 6.
+		/// </summary>
+		/// <param name="name"></param>
+		/// <returns></returns>
+		private bool IsValidPrintAscii(string name, params char[] invalid)
+		{
+			if (name.IsEmpty()) return false;
+
+			foreach (var ch in name)
+			{
+				if (ch < 33) return false;
+				if (ch > 126) return false;
+				if (invalid.Contains(ch)) return false;
+			}
+
+			return true;
+		}
+
+		protected override string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message)
+		{
+			return _tmpl.Format(new
+			{
+				priority,
+				now,
+				host,
+				name,
+				procid,
+				msgid,
+				data = _structuredData ?? "",
+				message
+			});
+		}
+
+	}
+
 }

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.Sockets;
 using System.Text;
-using System.Xml;
 
 namespace Syslog.Framework.Logging
 {

--- a/src/Syslog.Framework.Logging/SyslogLoggerFactoryExtensions.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerFactoryExtensions.cs
@@ -1,13 +1,28 @@
-﻿//using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Syslog.Framework.Logging
 {
 	public static class SyslogLoggerFactoryExtensions
 	{
+
+		public static void AddSyslog(this ILoggerFactory loggerFactory, IConfigurationSection section, string hostName = null, LogLevel logLevel = LogLevel.Debug)
+		{
+			var settings = new SyslogLoggerSettings();
+			section.Bind(settings);
+			AddSyslog(loggerFactory, settings, hostName, logLevel);
+		}
+
 		public static void AddSyslog(this ILoggerFactory loggerFactory, SyslogLoggerSettings settings, string hostName = null, LogLevel logLevel = LogLevel.Debug)
 		{
 			loggerFactory.AddProvider(new SyslogLoggerProvider(settings, hostName ?? System.Environment.MachineName, logLevel));
+		}
+
+		public static void AddSyslog(this ILoggingBuilder logbldr, IConfigurationSection section, string hostName = null, LogLevel logLevel = LogLevel.Debug)
+		{
+			var settings = new SyslogLoggerSettings();
+			section.Bind(settings);
+			AddSyslog(logbldr, settings, hostName, logLevel);
 		}
 
 		public static void AddSyslog(this ILoggingBuilder logbldr, SyslogLoggerSettings settings, string hostName = null, LogLevel logLevel = LogLevel.Debug)

--- a/src/Syslog.Framework.Logging/SyslogLoggerFactoryExtensions.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerFactoryExtensions.cs
@@ -1,15 +1,19 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿//using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Syslog.Framework.Logging
 {
-    public static class SyslogLoggerFactoryExtensions
-    {
-        public static void AddSyslog(this ILoggerFactory loggerFactory, IConfigurationSection configuration, string hostName = "localhost", LogLevel logLevel = LogLevel.Debug)
-        {
-            var settings = new SyslogLoggerSettings();
-            configuration.Bind(settings);
-            loggerFactory.AddProvider(new SyslogLoggerProvider(settings, hostName, logLevel));
-        }
-    }
+	public static class SyslogLoggerFactoryExtensions
+	{
+		public static void AddSyslog(this ILoggerFactory loggerFactory, SyslogLoggerSettings settings, string hostName = null, LogLevel logLevel = LogLevel.Debug)
+		{
+			loggerFactory.AddProvider(new SyslogLoggerProvider(settings, hostName ?? System.Environment.MachineName, logLevel));
+		}
+
+		public static void AddSyslog(this ILoggingBuilder logbldr, SyslogLoggerSettings settings, string hostName = null, LogLevel logLevel = LogLevel.Debug)
+		{
+			logbldr.AddProvider(new SyslogLoggerProvider(settings, hostName ?? System.Environment.MachineName, logLevel));
+		}
+
+	}
 }

--- a/src/Syslog.Framework.Logging/SyslogLoggerFactoryExtensions.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerFactoryExtensions.cs
@@ -5,7 +5,6 @@ namespace Syslog.Framework.Logging
 {
 	public static class SyslogLoggerFactoryExtensions
 	{
-
 		public static void AddSyslog(this ILoggerFactory loggerFactory, IConfigurationSection section, string hostName = null, LogLevel logLevel = LogLevel.Debug)
 		{
 			var settings = new SyslogLoggerSettings();
@@ -29,6 +28,5 @@ namespace Syslog.Framework.Logging
 		{
 			logbldr.AddProvider(new SyslogLoggerProvider(settings, hostName ?? System.Environment.MachineName, logLevel));
 		}
-
 	}
 }

--- a/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
@@ -6,10 +6,10 @@ namespace Syslog.Framework.Logging
 {
 	public class SyslogLoggerProvider : ILoggerProvider
 	{
-		private SyslogLoggerSettings _settings;
-		private string _hostName;
-		private LogLevel _logLevel;
-		private IDictionary<string, ILogger> _loggers;
+		private readonly SyslogLoggerSettings _settings;
+		private readonly string _hostName;
+		private readonly LogLevel _logLevel;
+		private readonly IDictionary<string, ILogger> _loggers;
 
 		public SyslogLoggerProvider(SyslogLoggerSettings settings, string hostName, LogLevel logLevel)
 		{

--- a/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Syslog.Framework.Logging
@@ -20,11 +21,24 @@ namespace Syslog.Framework.Logging
 
         public ILogger CreateLogger(string name)
         {
-            if (!_loggers.ContainsKey(name))
-                _loggers[name] = new SyslogLogger(name, _settings, _hostName, _logLevel);
+			if (!_loggers.ContainsKey(name))
+				_loggers[name] = CreateLoggerInstance(name);
 
             return _loggers[name];
         }
+
+		private ILogger CreateLoggerInstance(string name)
+		{
+			switch(_settings.HeaderType)
+			{
+				case SyslogHeaderType.Rfc3164:
+					return new Syslog3164Logger(name, _settings, _hostName, _logLevel);
+				case SyslogHeaderType.Rfc5424v1:
+					return new Syslog5424v1Logger(name, _settings, _hostName, _logLevel);
+				default:
+					throw new InvalidOperationException($"SyslogHeaderType '{_settings.HeaderType.ToString()}' is not recognized.");
+			}
+		}
 
         public void Dispose()
         {

--- a/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
@@ -4,32 +4,32 @@ using Microsoft.Extensions.Logging;
 
 namespace Syslog.Framework.Logging
 {
-    public class SyslogLoggerProvider : ILoggerProvider
-    {
-        private SyslogLoggerSettings _settings;
-        private string _hostName;
-        private LogLevel _logLevel;
-        private IDictionary<string, ILogger> _loggers;
+	public class SyslogLoggerProvider : ILoggerProvider
+	{
+		private SyslogLoggerSettings _settings;
+		private string _hostName;
+		private LogLevel _logLevel;
+		private IDictionary<string, ILogger> _loggers;
 
-        public SyslogLoggerProvider(SyslogLoggerSettings settings, string hostName, LogLevel logLevel)
-        {
-            _settings = settings;
-            _hostName = hostName;
-            _logLevel = logLevel;
-            _loggers = new Dictionary<string, ILogger>();
-        }
+		public SyslogLoggerProvider(SyslogLoggerSettings settings, string hostName, LogLevel logLevel)
+		{
+			_settings = settings;
+			_hostName = hostName;
+			_logLevel = logLevel;
+			_loggers = new Dictionary<string, ILogger>();
+		}
 
-        public ILogger CreateLogger(string name)
-        {
+		public ILogger CreateLogger(string name)
+		{
 			if (!_loggers.ContainsKey(name))
 				_loggers[name] = CreateLoggerInstance(name);
 
-            return _loggers[name];
-        }
+			return _loggers[name];
+		}
 
 		private ILogger CreateLoggerInstance(string name)
 		{
-			switch(_settings.HeaderType)
+			switch (_settings.HeaderType)
 			{
 				case SyslogHeaderType.Rfc3164:
 					return new Syslog3164Logger(name, _settings, _hostName, _logLevel);
@@ -40,9 +40,14 @@ namespace Syslog.Framework.Logging
 			}
 		}
 
-        public void Dispose()
-        {
-            _loggers.Clear();
-        }
-    }
+		public ILogger CreateLogger<T>()
+		{
+			return CreateLogger(typeof(T).FullName);
+		}
+
+		public void Dispose()
+		{
+			_loggers.Clear();
+		}
+	}
 }

--- a/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
@@ -4,7 +4,6 @@ namespace Syslog.Framework.Logging
 {
 	public class SyslogLoggerSettings
 	{
-
 		#region Fields and Methods
 
 		/// <summary>
@@ -38,7 +37,6 @@ namespace Syslog.Framework.Logging
 		public bool UseUtc { get; set; } = false; // Default to false to be backwards compatible with v1.
 
 		#endregion
-
 	}
 
 	/// <summary>
@@ -46,7 +44,6 @@ namespace Syslog.Framework.Logging
 	/// </summary>
 	public class SyslogStructuredData
 	{
-
 		/// <summary>
 		/// Creates an instance of SyslogStructuredData.
 		/// </summary>
@@ -72,7 +69,6 @@ namespace Syslog.Framework.Logging
 		/// Gets the list of structured data elements.
 		/// </summary>
 		public IEnumerable<SylogStructuredDataElement> Elements { get; set; }
-
 	}
 
 	/// <summary>
@@ -80,7 +76,6 @@ namespace Syslog.Framework.Logging
 	/// </summary>
 	public class SylogStructuredDataElement
 	{
-
 		/// <summary>
 		/// Creates an instance of SylogStructuredDataElement.
 		/// </summary>
@@ -108,6 +103,5 @@ namespace Syslog.Framework.Logging
 		/// Gets the value of the element.
 		/// </summary>
 		public string Value { get; set; }
-
 	}
 }

--- a/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
@@ -14,12 +14,12 @@ namespace Syslog.Framework.Logging
 		/// <summary>
 		/// Gets or sets the host for the Syslog server.
 		/// </summary>
-		public string ServerHost { get; set; }
+		public string ServerHost { get; set; } = "127.0.0.1";
 
 		/// <summary>
 		/// Gets or sets the port for the Syslog server.
 		/// </summary>
-		public int ServerPort { get; set; }
+		public int ServerPort { get; set; } = 514;
 
 		/// <summary>
 		/// Gets or sets the facility type.
@@ -34,7 +34,7 @@ namespace Syslog.Framework.Logging
 		/// <summary>
 		/// Structured data that is sent with every request. Only for RFC 5424.
 		/// </summary>
-		public List<SyslogStructuredData> StructuredData { get; private set; } = new List<SyslogStructuredData>();
+		public IEnumerable<SyslogStructuredData> StructuredData { get; set; }
 
 		/// <summary>
 		/// Gets or sets whether to log messages using UTC or local time. Defaults to true (UTC).
@@ -44,12 +44,19 @@ namespace Syslog.Framework.Logging
 		#endregion
 
 	}
-	
+
 	/// <summary>
 	/// Allows sending of structured data in RFC 5424.
 	/// </summary>
 	public class SyslogStructuredData
 	{
+
+		/// <summary>
+		/// Creates an instance of SyslogStructuredData.
+		/// </summary>
+		public SyslogStructuredData()
+		{
+		}
 
 		/// <summary>
 		/// Creates an instance of SyslogStructuredData.
@@ -63,12 +70,12 @@ namespace Syslog.Framework.Logging
 		/// <summary>
 		/// Gets the ID for the structured data.
 		/// </summary>
-		public string Id { get; private set; }
+		public string Id { get; set; }
 
 		/// <summary>
 		/// Gets the list of structured data elements.
 		/// </summary>
-		public List<SylogStructuredDataElement> Elements { get; private set; } = new List<SylogStructuredDataElement>();
+		public IEnumerable<SylogStructuredDataElement> Elements { get; set; }
 
 	}
 
@@ -77,6 +84,13 @@ namespace Syslog.Framework.Logging
 	/// </summary>
 	public class SylogStructuredDataElement
 	{
+
+		/// <summary>
+		/// Creates an instance of SylogStructuredDataElement.
+		/// </summary>
+		public SylogStructuredDataElement()
+		{
+		}
 
 		/// <summary>
 		/// Creates an instance of SylogStructuredDataElement.
@@ -92,12 +106,12 @@ namespace Syslog.Framework.Logging
 		/// <summary>
 		/// Gets the name of the element.
 		/// </summary>
-		public string Name { get; private set; }
+		public string Name { get; set; }
 
 		/// <summary>
 		/// Gets the value of the element.
 		/// </summary>
-		public string Value { get; private set; }
+		public string Value { get; set; }
 
 	}
 }

--- a/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
@@ -1,8 +1,4 @@
-﻿using BizArk.Core.Extensions.StringExt;
-using BizArk.Core.Util;
-using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
 
 namespace Syslog.Framework.Logging
 {
@@ -29,7 +25,7 @@ namespace Syslog.Framework.Logging
 		/// <summary>
 		/// Gets or sets the header type. Set this instead of HeaderFormat.
 		/// </summary>
-		public SyslogHeaderType HeaderType { get; set; } = SyslogHeaderType.Rfc3164;
+		public SyslogHeaderType HeaderType { get; set; } = SyslogHeaderType.Rfc3164; // Default to 3164 to be backwards compatible with v1.
 
 		/// <summary>
 		/// Structured data that is sent with every request. Only for RFC 5424.
@@ -37,9 +33,9 @@ namespace Syslog.Framework.Logging
 		public IEnumerable<SyslogStructuredData> StructuredData { get; set; }
 
 		/// <summary>
-		/// Gets or sets whether to log messages using UTC or local time. Defaults to true (UTC).
+		/// Gets or sets whether to log messages using UTC or local time. Defaults to false (use local time).
 		/// </summary>
-		public bool UseUtc { get; set; } = true;
+		public bool UseUtc { get; set; } = false; // Default to false to be backwards compatible with v1.
 
 		#endregion
 

--- a/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
@@ -1,8 +1,103 @@
-﻿namespace Syslog.Framework.Logging
+﻿using BizArk.Core.Extensions.StringExt;
+using BizArk.Core.Util;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Syslog.Framework.Logging
 {
-    public class SyslogLoggerSettings
-    {
-        public string ServerHost { get; set; }
-        public int ServerPort { get; set; }
-    }
+	public class SyslogLoggerSettings
+	{
+
+		#region Fields and Methods
+
+		/// <summary>
+		/// Gets or sets the host for the Syslog server.
+		/// </summary>
+		public string ServerHost { get; set; }
+
+		/// <summary>
+		/// Gets or sets the port for the Syslog server.
+		/// </summary>
+		public int ServerPort { get; set; }
+
+		/// <summary>
+		/// Gets or sets the facility type.
+		/// </summary>
+		public FacilityType FacilityType { get; set; } = FacilityType.Local0;
+
+		/// <summary>
+		/// Gets or sets the header type. Set this instead of HeaderFormat.
+		/// </summary>
+		public SyslogHeaderType HeaderType { get; set; } = SyslogHeaderType.Rfc3164;
+
+		/// <summary>
+		/// Structured data that is sent with every request. Only for RFC 5424.
+		/// </summary>
+		public List<SyslogStructuredData> StructuredData { get; private set; } = new List<SyslogStructuredData>();
+
+		/// <summary>
+		/// Gets or sets whether to log messages using UTC or local time. Defaults to true (UTC).
+		/// </summary>
+		public bool UseUtc { get; set; } = true;
+
+		#endregion
+
+	}
+	
+	/// <summary>
+	/// Allows sending of structured data in RFC 5424.
+	/// </summary>
+	public class SyslogStructuredData
+	{
+
+		/// <summary>
+		/// Creates an instance of SyslogStructuredData.
+		/// </summary>
+		/// <param name="id"></param>
+		public SyslogStructuredData(string id)
+		{
+			Id = id;
+		}
+
+		/// <summary>
+		/// Gets the ID for the structured data.
+		/// </summary>
+		public string Id { get; private set; }
+
+		/// <summary>
+		/// Gets the list of structured data elements.
+		/// </summary>
+		public List<SylogStructuredDataElement> Elements { get; private set; } = new List<SylogStructuredDataElement>();
+
+	}
+
+	/// <summary>
+	/// A named value for structured data.
+	/// </summary>
+	public class SylogStructuredDataElement
+	{
+
+		/// <summary>
+		/// Creates an instance of SylogStructuredDataElement.
+		/// </summary>
+		/// <param name="name"></param>
+		/// <param name="value"></param>
+		public SylogStructuredDataElement(string name, string value)
+		{
+			Name = name;
+			Value = value;
+		}
+
+		/// <summary>
+		/// Gets the name of the element.
+		/// </summary>
+		public string Name { get; private set; }
+
+		/// <summary>
+		/// Gets the value of the element.
+		/// </summary>
+		public string Value { get; private set; }
+
+	}
 }


### PR DESCRIPTION
This pull request adds support for [RFC 5424](https://tools.ietf.org/html/rfc5424) of the Syslog protocol. It maintains backwards compatibility with v2 of this project (hopefully, not actually tested, but reviewed). 

I did resolve the async issue that was reported (no longer using async). This might be a problem in high volume systems, along with the ti24horas concern about re-instantiating the UDP client for every log request. I did this work in order to evaluate a possible logging solution that supported Syslog, so didn't put much effort into improving the performance.

If you do look into the async issue more, check out this thread: https://social.msdn.microsoft.com/Forums/vstudio/en-US/cbdd9818-00f0-499f-a935-d8e555899d64/use-net-udpclient-in-a-multithreaded-env?forum=wcf