### PR TITLE
Minor violations of RFC5424

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,11 @@ namespace MySyslogConsoleApp
   }
 }
 ```
+### Release notes
+#### 2.1.2
+Made changes to a RFC 5424 message sent by the library to fix some deviations from the RFC 5424 standard:
+* If any message header has no value a NILVALUE (-) is now written as the header value instead of just skipping the header. This fixes a bug where a part of message could be interpreted as structured data and the message malformed when it started with square braces followed by a colon and the message had no structured data assigned.
+* The timestamp is now written with 6 digits in a second fraction part as is mandated by the standard. Previously 7 digits have been written causing some syslog server implementations (such as rsyslog) to incorrectly display that part.
+* If we fail to retrieve the process id a NILVALUE is sent instead of 0.
+
+Aside from fixing the aforementioned bugs the changes should be transparent to any RFC 5424 compliant syslog server implementation.

--- a/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
+++ b/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
@@ -16,7 +16,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Net.Sockets;
 using System.Text;
@@ -202,7 +203,16 @@ namespace Syslog.Framework.Logging
 
 		protected override string FormatMessage(int priority, DateTime now, string host, string name, int? procid, int msgid, string message)
 		{
-			return $"<{priority}>1 {now:o} {host ?? NilValue} {name ?? NilValue} {procid?.ToString() ?? NilValue} {msgid} {_structuredData ?? NilValue} {message}";
+			var formattedTimestamp = FormatTimestamp(now);
+			return $"<{priority}>1 {formattedTimestamp} {host ?? NilValue} {name ?? NilValue} {procid?.ToString() ?? NilValue} {msgid} {_structuredData ?? NilValue} {message}";
+		}
+
+		/// <summary>
+		/// Formats the date as required by RFC 5424.
+		/// </summary>
+		private string FormatTimestamp(DateTime time)
+		{
+			return time.ToString("yyyy-MM-ddTHH:mm:ss.ffffffK", CultureInfo.InvariantCulture);
 		}
 	}
 }

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -147,7 +147,6 @@ namespace Syslog.Framework.Logging
                 return null;
 			
 			var sb = new StringBuilder();
-			sb.Append(" "); // Need to add a space to separate what came before it.
 
 			foreach (var data in settings.StructuredData)
 			{
@@ -172,7 +171,7 @@ namespace Syslog.Framework.Logging
 					}
 				}
 
-                sb.Append("]");
+            sb.Append("]");
 			}
 
 			return sb.ToString();

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -123,6 +123,7 @@ namespace Syslog.Framework.Logging
 	/// </summary>
 	public class Syslog5424v1Logger : SyslogLogger
 	{
+		private const string NilValue = "-";
 		private readonly string _structuredData;
 
 		public Syslog5424v1Logger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
@@ -136,7 +137,7 @@ namespace Syslog.Framework.Logging
 			if (settings.StructuredData == null)
                 return null;
 
-			if (settings.StructuredData.Count() == 0)
+			if (!settings.StructuredData.Any())
                 return null;
 			
 			var sb = new StringBuilder();
@@ -196,8 +197,7 @@ namespace Syslog.Framework.Logging
 
 		protected override string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message)
 		{
-            var data = _structuredData ?? String.Empty;
-            return $"<{priority}>1 {now:o} {host} {name} {procid} {msgid} {data} {message}";
+            return $"<{priority}>1 {now:o} {host ?? NilValue} {name ?? NilValue} {procid} {msgid} {_structuredData ?? NilValue} {message}";
 		}
 	}
 }

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -197,7 +197,7 @@ namespace Syslog.Framework.Logging
 		protected override string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message)
 		{
             var data = _structuredData ?? String.Empty;
-            return $"<{priority}>1 {now:o} {host} {name} {procid} {msgid}{data} {message}";
+            return $"<{priority}>1 {now:o} {host} {name} {procid} {msgid} {data} {message}";
 		}
 	}
 }

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -13,6 +13,7 @@ namespace Syslog.Framework.Logging
 		private readonly string _host;
 		private readonly LogLevel _lvl;
 		private readonly SyslogLoggerSettings _settings;
+		private readonly int? _processId;
 
 		public SyslogLogger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
 		{
@@ -20,6 +21,7 @@ namespace Syslog.Framework.Logging
 			_settings = settings;
 			_host = host;
 			_lvl = lvl;
+			_processId = GetProcID();
 		}
 
 		public IDisposable BeginScope<TState>(TState state)
@@ -49,9 +51,8 @@ namespace Syslog.Framework.Logging
 			// If a different value is needed, then this code should probably move into the specific loggers.
 			var severity = MapToSeverityType(logLevel);
 			var priority = ((int)_settings.FacilityType * 8) + (int)severity;
-			var procid = GetProcID();
 			var now = _settings.UseUtc ? DateTime.UtcNow : DateTime.Now;
-			var msg = FormatMessage(priority, now, _host, _name, procid, eventId.Id, message);
+			var msg = FormatMessage(priority, now, _host, _name, _processId, eventId.Id, message);
 			var raw = Encoding.ASCII.GetBytes(msg);
 
 			using (var udp = new UdpClient())
@@ -60,26 +61,30 @@ namespace Syslog.Framework.Logging
 			}
 		}
 
-		protected abstract string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message);
-
-		private int? _procID;
-		private int GetProcID()
+		[Obsolete("Left for backward compatibility only. Will be removed in future. Override the other method overload")]
+		protected virtual string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message)
 		{
-			if (_procID == null)
-			{
-				try
-				{
-					// Attempt to get the process ID. This might not work on all platforms.
-					_procID = Process.GetCurrentProcess().Id;
-				}
-				catch
-				{
-					// If we can't get it, just default to 0.
-					_procID = 0;
-				}
-			}
+			throw new NotImplementedException($"You have to provide implementation for a {nameof(FormatMessage)} method.");
+		}
 
-			return _procID.Value;
+		protected virtual string FormatMessage(int priority, DateTime now, string host, string name, int? procid, int msgid, string message)
+		{
+#pragma warning disable 618
+			return FormatMessage(priority, now, host, name, procid ?? 0, msgid, message);
+#pragma warning restore 618
+		}
+
+		private int? GetProcID()
+		{
+			try
+			{
+				// Attempt to get the process ID. This might not work on all platforms.
+				return Process.GetCurrentProcess().Id;
+			}
+			catch
+			{
+				return null;
+			}
 		}
 
 		internal virtual SeverityType MapToSeverityType(LogLevel logLevel)
@@ -110,7 +115,7 @@ namespace Syslog.Framework.Logging
 		{
 		}
 
-		protected override string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message)
+		protected override string FormatMessage(int priority, DateTime now, string host, string name, int? procid, int msgid, string message)
 		{
             var tag = name.Replace(".", String.Empty).Replace("_", String.Empty); // Alphanumeric
             tag = tag.Substring(0, Math.Min(32, tag.Length)); // Max length is 32 according to spec
@@ -195,9 +200,9 @@ namespace Syslog.Framework.Logging
 			return true;
 		}
 
-		protected override string FormatMessage(int priority, DateTime now, string host, string name, int procid, int msgid, string message)
+		protected override string FormatMessage(int priority, DateTime now, string host, string name, int? procid, int msgid, string message)
 		{
-            return $"<{priority}>1 {now:o} {host ?? NilValue} {name ?? NilValue} {procid} {msgid} {_structuredData ?? NilValue} {message}";
+			return $"<{priority}>1 {now:o} {host ?? NilValue} {name ?? NilValue} {procid?.ToString() ?? NilValue} {msgid} {_structuredData ?? NilValue} {message}";
 		}
 	}
 }


### PR DESCRIPTION
This pull request fixes 2 bugs due to a few minor deviations from RFC5424.

1. When you write log without structured data and with braces followed by a colon at the beginning of a message the first part of the message will be incorrectly parsed as structured data and the rest of the message will be malformed. This happens because we do not write anything in a structured data message part when there is no structured data as opposed to a "-" char as is mandated by the standard.
2. In rsyslog the time part for milliseconds is malformed because we send that part with 7 digits and RFC5424 mandates exactly the same format as we use but with 6 digits for second fraction.

Example:
```
var logger = loggerFactory.CreateLogger("TEST");

var correlationId = 1;
logger.LogInformation($"[{correlationId}]: Starting...");
```

Output in syslog file with current master version in rsyslog:
- RSYSLOG_TraditionalFileFormat:
`Dec 19 13:24:25 Komputer TEST[19565] .`
- RSYSLOG_SyslogProtocol23Format (note that the bracket is where structured data should be, note also the malformed millisecond part)
`<134>1 2018-12-19T13:23:05.�+01:00 Komputer TEST 19046 0 [1]: Starting.. .`

After fixes:
- RSYSLOG_TraditionalFileFormat:
`Dec 19 13:26:32 Komputer TEST[20683] [1]: Starting...`
- RSYSLOG_SyslogProtocol23Format
`<134>1 2018-12-19T13:26:56.427477+01:00 Komputer TEST 20856 0 - [1]: Starting...`

Tested on:
- Xubuntu 16.04, rsyslog 8.16.0,
- Raspbian Stretch, rsyslog 8.24.0