### PR TITLE
Support for UNIX sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To use this transport protocol change your config to include the following lines
     "UnixSocketPath": "/dev/log"
 }
 ```
-#### Using custom protocol
+#### Adding custom protocol
 If built-in protocols aren't enough you can add support for any protocol by implementing just 1 simple interface - `IMessageSender`.
 
 For example, to use Tcp protocol you could write this simple class (note - this is just an example designed for simplicity, NOT a production ready implementation):
@@ -184,3 +184,7 @@ Made changes to a RFC 5424 message sent by the library to fix some deviations fr
 * If we fail to retrieve the process id a NILVALUE is sent instead of 0.
 
 Aside from fixing the aforementioned bugs the changes should be transparent to any RFC 5424 compliant syslog server implementation.
+
+#### 2.2.0
+* Support for sending messages by UNIX domain sockets.
+* Support for custom transport procotol implementations.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ The Syslog implementation supports the following features:
 
  - RFC 3164
  - RFC 5424 (v1)
- - Structure data (RFC 5424 only)
+ - Structured data (RFC 5424 only)
  - UTC or local time stamps
+ - UDP and Unix sockets as message transport protocols,
+ - Can be extended with custom message transport procotol,
  - Custom facility types
 
 ### Instructions
@@ -19,6 +21,7 @@ Next in appsettings.json add the following and modify where necessary:
 
     {
       "SyslogSettings": {
+        "MessageTransportProtocol": "Udp",
         "ServerHost": "127.0.0.1",
         "ServerPort": 514,
         "HeaderType": "Rfc5424v1",
@@ -100,6 +103,79 @@ namespace MySyslogConsoleApp
   }
 }
 ```
+### Message transport protocols
+A message transport protocol defines means by which the message is delivered to a syslog server.
+This library currently has the following built-in transport protocols:
+#### UDP
+A fast but unreliable protocol. When using UDP be aware that messages can be lost or they can be delivered out of order. Allows sending of messages directly to a remote server.
+
+To use this transport protocol configure your syslog server to accept UDP messages and change your config to include the following lines (change the server host and port according to your server configuration):
+```
+"SyslogSettings": {
+    "MessageTransportProtocol": "Udp",
+    "ServerHost": "127.0.0.1",
+    "ServerPort": 514
+}
+```
+#### Unix domain sockets
+A fast and reliable protocol for sending messages to a local syslog server on Unix systems. Does NOT support sending of messages to a remote server (but note that most syslog server implementations can be configured to forward the messages to a centralized server, also with advanced features such as queueing the messages if the server is unavailable). 
+
+Note that by default most syslog servers (at least rsyslog is) are configured to expect special message format for default `/dev/log` socket. This message format is inflexible and is not supported by this library. If you want to use this transport protocol you have to configure the server to listen to additional socket in standard format or reconfigure the default socket. 
+
+In rsyslog you can reconfigure the /dev/log socket to use the same format as for messages sent by Udp or Tcp by replacing the following entry in `/etc/rsyslog.conf`:
+
+`module(load="imuxsock") # provides support for local system logging`
+
+with
+
+`module(load="imuxsock" SysSock.UseSpecialParser="off") # provides support for local system logging`
+
+Note that during testing we did not encounter any side effects when disabling special message format for `/dev/log` but there is a possibility that logs coming from some applications using that format can be malformed so depending on your requirements the usage of an additional socket in different path can be better solution.
+
+To use this transport protocol change your config to include the following lines (change the socket path if it is different than /dev/log):
+```
+"SyslogSettings": {
+    "MessageTransportProtocol": "UnixSocket",
+    "UnixSocketPath": "/dev/log"
+}
+```
+#### Using custom protocol
+If built-in protocols aren't enough you can add support for any protocol by implementing just 1 simple interface - `IMessageSender`.
+
+For example, to use Tcp protocol you could write this simple class (note - this is just an example designed for simplicity, NOT a production ready implementation):
+```
+public class TcpMessageSender : IMessageSender
+{
+   public void SendMessageToServer(byte[] messageData)
+   {
+      using (var tcp = new TcpClient())
+      {
+         tcp.Connect("127.0.0.1", 514);
+				
+         using (var stream = tcp.GetStream())
+         {
+            stream.Write(messageData, 0, messageData.Length);
+            stream.WriteByte((byte)'\n');
+         }
+      }
+   }
+}
+```
+And then tell the library to use this protocol implementation by assigning an object of this class to a `CustomMessageSender` property of `SyslogLoggerSettings`:
+```
+    CreateWebHostBuilder(args)
+    .ConfigureLogging((ctx, logging) =>
+    {
+        var slConfig = ctx.Configuration.GetSection("SyslogSettings");
+        
+        logging.AddSyslog(slConfig, x =>
+        {
+            x.CustomMessageSender = new TcpMessageSender();
+        });
+    }
+```
+If you have written a generic implementation of protocol not currently supported by the library and you think it can be useful to more people you are encouraged to contribute the implementation to the project.
+
 ### Release notes
 #### 2.1.2
 Made changes to a RFC 5424 message sent by the library to fix some deviations from the RFC 5424 standard:

--- a/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
+++ b/src/Syslog.Framework.Logging/Syslog.Framework.Logging.csproj
@@ -16,7 +16,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.1.2</Version>
+    <Version>2.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 using Syslog.Framework.Logging.TransportProtocols;
+using Syslog.Framework.Logging.TransportProtocols.Udp;
 
 namespace Syslog.Framework.Logging
 {
@@ -18,6 +19,12 @@ namespace Syslog.Framework.Logging
 		private readonly int? _processId;
 		private readonly IMessageSender _messageSender;
 
+		[Obsolete("Remains for backward compatibility. Will be removed in future. Use the other overload.")]
+		public SyslogLogger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
+			: this(name, settings, host, lvl, new UdpMessageSender(settings.ServerHost, settings.ServerPort))
+		{
+		}
+		
 		public SyslogLogger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl, IMessageSender messageSender)
 		{
 			_name = name;
@@ -120,6 +127,12 @@ namespace Syslog.Framework.Logging
 	/// </summary>
 	public class Syslog3164Logger : SyslogLogger
 	{
+		[Obsolete("Remains for backward compatibility. Will be removed in future. Use the other overload.")]
+		public Syslog3164Logger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
+			: base(name, settings, host, lvl)
+		{
+		}
+		
 		public Syslog3164Logger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl, IMessageSender messageSender)
 			: base(name, settings, host, lvl, messageSender)
 		{
@@ -140,6 +153,12 @@ namespace Syslog.Framework.Logging
 	{
 		private const string NilValue = "-";
 		private readonly string _structuredData;
+		
+		[Obsolete("Remains for backward compatibility. Will be removed in future. Use the other overload.")]
+		public Syslog5424v1Logger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl)
+			: base(name, settings, host, lvl)
+		{
+		}
 
 		public Syslog5424v1Logger(string name, SyslogLoggerSettings settings, string host, LogLevel lvl, IMessageSender messageSender)
 			: base(name, settings, host, lvl, messageSender)

--- a/src/Syslog.Framework.Logging/SyslogLogger.cs
+++ b/src/Syslog.Framework.Logging/SyslogLogger.cs
@@ -59,7 +59,16 @@ namespace Syslog.Framework.Logging
 			var msg = FormatMessage(priority, now, _host, _name, _processId, eventId.Id, message);
 			var raw = Encoding.ASCII.GetBytes(msg);
 
-			_messageSender.SendMessageToServer(raw);
+			try
+			{
+				_messageSender.SendMessageToServer(raw);
+			}
+			catch (Exception ex)
+			{
+				// Do not rethrow exception. Crashing an application just because logging has failed due to a transient unavailability of syslog server
+				// does not look like a good practice.
+				Console.Error.WriteLine("Logging failed." + ex);
+			}
 		}
 
 		[Obsolete("Left for backward compatibility only. Will be removed in future. Override the other method overload")]

--- a/src/Syslog.Framework.Logging/SyslogLoggerFactoryExtensions.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerFactoryExtensions.cs
@@ -1,14 +1,16 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Syslog.Framework.Logging
 {
 	public static class SyslogLoggerFactoryExtensions
 	{
-		public static void AddSyslog(this ILoggerFactory loggerFactory, IConfigurationSection section, string hostName = null, LogLevel logLevel = LogLevel.Debug)
+		public static void AddSyslog(this ILoggerFactory loggerFactory, IConfigurationSection section, Action<SyslogLoggerSettings> configurator = null, string hostName = null, LogLevel logLevel = LogLevel.Debug)
 		{
 			var settings = new SyslogLoggerSettings();
 			section.Bind(settings);
+			configurator?.Invoke(settings);
 			AddSyslog(loggerFactory, settings, hostName, logLevel);
 		}
 
@@ -17,10 +19,11 @@ namespace Syslog.Framework.Logging
 			loggerFactory.AddProvider(new SyslogLoggerProvider(settings, hostName ?? System.Environment.MachineName, logLevel));
 		}
 
-		public static void AddSyslog(this ILoggingBuilder logbldr, IConfigurationSection section, string hostName = null, LogLevel logLevel = LogLevel.Debug)
+		public static void AddSyslog(this ILoggingBuilder logbldr, IConfigurationSection section, Action<SyslogLoggerSettings> configurator = null, string hostName = null, LogLevel logLevel = LogLevel.Debug)
 		{
 			var settings = new SyslogLoggerSettings();
 			section.Bind(settings);
+			configurator?.Invoke(settings);
 			AddSyslog(logbldr, settings, hostName, logLevel);
 		}
 

--- a/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
@@ -18,7 +18,7 @@ namespace Syslog.Framework.Logging
 			_settings = settings;
 			_hostName = hostName;
 			_logLevel = logLevel;
-			_messageSender = MessageSenderFactory.CreateFromSettings(settings);
+			_messageSender = settings.CustomMessageSender ?? MessageSenderFactory.CreateFromSettings(settings);
 			_loggers = new Dictionary<string, ILogger>();
 		}
 

--- a/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using Syslog.Framework.Logging.TransportProtocols;
 
 namespace Syslog.Framework.Logging
 {
@@ -10,12 +11,14 @@ namespace Syslog.Framework.Logging
 		private readonly string _hostName;
 		private readonly LogLevel _logLevel;
 		private readonly IDictionary<string, ILogger> _loggers;
+		private readonly IMessageSender _messageSender;
 
 		public SyslogLoggerProvider(SyslogLoggerSettings settings, string hostName, LogLevel logLevel)
 		{
 			_settings = settings;
 			_hostName = hostName;
 			_logLevel = logLevel;
+			_messageSender = MessageSenderFactory.CreateFromSettings(settings);
 			_loggers = new Dictionary<string, ILogger>();
 		}
 
@@ -32,9 +35,9 @@ namespace Syslog.Framework.Logging
 			switch (_settings.HeaderType)
 			{
 				case SyslogHeaderType.Rfc3164:
-					return new Syslog3164Logger(name, _settings, _hostName, _logLevel);
+					return new Syslog3164Logger(name, _settings, _hostName, _logLevel, _messageSender);
 				case SyslogHeaderType.Rfc5424v1:
-					return new Syslog5424v1Logger(name, _settings, _hostName, _logLevel);
+					return new Syslog5424v1Logger(name, _settings, _hostName, _logLevel, _messageSender);
 				default:
 					throw new InvalidOperationException($"SyslogHeaderType '{_settings.HeaderType.ToString()}' is not recognized.");
 			}

--- a/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Syslog.Framework.Logging.TransportProtocols;
 
 namespace Syslog.Framework.Logging
 {
@@ -7,15 +8,34 @@ namespace Syslog.Framework.Logging
 		#region Fields and Methods
 
 		/// <summary>
+		/// Gets or sets the protocol used to send messages to a Syslog server.
+		/// </summary>
+		public TransportProtocol MessageTransportProtocol { get; set; } = TransportProtocol.Udp;
+		
+		/// <summary>
 		/// Gets or sets the host for the Syslog server.
 		/// </summary>
+		/// <remarks>
+		/// Used only when <see cref="MessageTransportProtocol"/> is set to <see cref="TransportProtocol.Udp"/>.
+		/// </remarks>
 		public string ServerHost { get; set; } = "127.0.0.1";
 
 		/// <summary>
 		/// Gets or sets the port for the Syslog server.
 		/// </summary>
+		/// <remarks>
+		/// Used only when <see cref="MessageTransportProtocol"/> is set to <see cref="TransportProtocol.Udp"/>.
+		/// </remarks>
 		public int ServerPort { get; set; } = 514;
 
+		/// <summary>
+		/// Gets or sets the path to a Unix socket for logging.
+		/// </summary>
+		/// <remarks>
+		/// Used only when <see cref="MessageTransportProtocol"/> is set to <see cref="TransportProtocol.UnixSocket"/>.
+		/// </remarks>
+		public string UnixSocketPath { get; set; } = "/dev/log";
+		
 		/// <summary>
 		/// Gets or sets the facility type.
 		/// </summary>

--- a/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
+++ b/src/Syslog.Framework.Logging/SyslogLoggerSettings.cs
@@ -56,6 +56,14 @@ namespace Syslog.Framework.Logging
 		/// </summary>
 		public bool UseUtc { get; set; } = false; // Default to false to be backwards compatible with v1.
 
+		/// <summary>
+		/// Gets or sets custom implementation of transport protocol.
+		/// </summary>
+		/// <remarks>
+		/// When it is set, <see cref="MessageTransportProtocol"/> is ignored.
+		/// </remarks>
+		public IMessageSender CustomMessageSender { get; set; } 
+
 		#endregion
 	}
 

--- a/src/Syslog.Framework.Logging/TransportProtocols/IMessageSender.cs
+++ b/src/Syslog.Framework.Logging/TransportProtocols/IMessageSender.cs
@@ -1,0 +1,10 @@
+namespace Syslog.Framework.Logging.TransportProtocols
+{
+	/// <summary>
+	/// An interface used for sending serialized messages to a Syslog server.
+	/// </summary>
+	public interface IMessageSender
+	{
+		void SendMessageToServer(byte[] messageData);
+	}
+}

--- a/src/Syslog.Framework.Logging/TransportProtocols/MessageSenderFactory.cs
+++ b/src/Syslog.Framework.Logging/TransportProtocols/MessageSenderFactory.cs
@@ -1,0 +1,22 @@
+using System;
+using Syslog.Framework.Logging.TransportProtocols.Udp;
+using Syslog.Framework.Logging.TransportProtocols.UnixSockets;
+
+namespace Syslog.Framework.Logging.TransportProtocols
+{
+	internal static class MessageSenderFactory
+	{
+		public static IMessageSender CreateFromSettings(SyslogLoggerSettings settings)
+		{
+			switch (settings.MessageTransportProtocol)
+			{
+				case TransportProtocol.Udp:
+					return new UdpMessageSender(settings.ServerHost, settings.ServerPort);
+				case TransportProtocol.UnixSocket:
+					return new UnixSocketMessageSender(settings.UnixSocketPath);
+				default:
+					throw new InvalidOperationException($"{nameof(TransportProtocol)} '{settings.MessageTransportProtocol}' is not recognized.");
+			}
+		}
+	}
+}

--- a/src/Syslog.Framework.Logging/TransportProtocols/TransportProtocol.cs
+++ b/src/Syslog.Framework.Logging/TransportProtocols/TransportProtocol.cs
@@ -1,0 +1,27 @@
+namespace Syslog.Framework.Logging.TransportProtocols
+{
+	/// <summary>
+	/// Available built-in transport protocols used for sending logs to a syslog server.
+	/// </summary>
+	public enum TransportProtocol
+	{
+		/// <summary>
+		/// Sends the logs using UDP datagrams.
+		/// </summary>
+		Udp,
+		
+		/// <summary>
+		/// Sends the logs using local UNIX sockets.
+		/// </summary>
+		/// <remarks>
+		/// Note that depending on syslog server UNIX sockets can expect different message format than other protocols.
+		/// This is the case on rsyslog by default. If you want to use UNIX socket logging using this library you should
+		/// set UseSpecialParser="off" either for default /dev/log socket or add new socket with this special parser disabled.
+		/// Example configuration for /dev/log in rsyslog.conf:
+		/// <example>
+		///    module(load="imuxsock" SysSock.UseSpecialParser="off")
+		/// </example>
+		/// </remarks>
+		UnixSocket
+	}
+}

--- a/src/Syslog.Framework.Logging/TransportProtocols/Udp/UdpMessageSender.cs
+++ b/src/Syslog.Framework.Logging/TransportProtocols/Udp/UdpMessageSender.cs
@@ -1,0 +1,27 @@
+using System.Net.Sockets;
+
+namespace Syslog.Framework.Logging.TransportProtocols.Udp
+{
+	/// <summary>
+	/// Sends message to a syslog server using UDP datagrams.
+	/// </summary>
+	public class UdpMessageSender : IMessageSender
+	{
+		private readonly string _serverHost;
+		private readonly int _serverPort;
+
+		public UdpMessageSender(string serverHost, int serverPort)
+		{
+			_serverHost = serverHost;
+			_serverPort = serverPort;
+		}
+
+		public void SendMessageToServer(byte[] messageData)
+		{
+			using (var udp = new UdpClient())
+			{
+				udp.Send(messageData, messageData.Length, _serverHost, _serverPort);
+			}
+		}
+	}
+}

--- a/src/Syslog.Framework.Logging/TransportProtocols/UnixSockets/UnixDomainSocketEndpoint.cs
+++ b/src/Syslog.Framework.Logging/TransportProtocols/UnixSockets/UnixDomainSocketEndpoint.cs
@@ -1,0 +1,100 @@
+// This file was copied from https://github.com/dotnet/corefx/blob/d0dc5fc099946adc1035b34a8b1f6042eddb0c75/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs#L248
+// as System.Net.Socket.UnixDomainSocketEndPoint is not available in NETStandard 2.0
+ 
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace Syslog.Framework.Logging.TransportProtocols.UnixSockets
+{
+	/// <summary>
+	/// Version of System.Net.Sockets.UnixDomainSocketEndPoint copied from https://github.com/dotnet/corefx/blob/d0dc5fc099946adc1035b34a8b1f6042eddb0c75/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs#L248
+	/// as System.Net.Sockets.UnixDomainSocketEndPoint is not available in NETStandard 2.0
+	/// </summary>
+	internal sealed class UnixDomainSocketEndPoint : EndPoint
+	{
+		private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
+
+		private static readonly Encoding s_pathEncoding = Encoding.UTF8;
+
+		private static readonly int s_nativePathOffset = 2; // = offsetof(struct sockaddr_un, sun_path). It's the same on Linux and OSX
+		private static readonly int s_nativePathLength = 91; // sockaddr_un.sun_path at http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html, -1 for terminator
+		private static readonly int s_nativeAddressSize = s_nativePathOffset + s_nativePathLength;
+
+		private readonly string _path;
+		private readonly byte[] _encodedPath;
+
+		public UnixDomainSocketEndPoint(string path)
+		{
+			if (path == null)
+			{
+				throw new ArgumentNullException(nameof(path));
+			}
+
+			_path = path;
+			_encodedPath = s_pathEncoding.GetBytes(_path);
+
+			if (path.Length == 0 || _encodedPath.Length > s_nativePathLength)
+			{
+				throw new ArgumentOutOfRangeException(nameof(path));
+			}
+		}
+
+		internal UnixDomainSocketEndPoint(SocketAddress socketAddress)
+		{
+			if (socketAddress == null)
+			{
+				throw new ArgumentNullException(nameof(socketAddress));
+			}
+
+			if (socketAddress.Family != EndPointAddressFamily ||
+			    socketAddress.Size > s_nativeAddressSize)
+			{
+				throw new ArgumentOutOfRangeException(nameof(socketAddress));
+			}
+
+			if (socketAddress.Size > s_nativePathOffset)
+			{
+				_encodedPath = new byte[socketAddress.Size - s_nativePathOffset];
+				for (int i = 0; i < _encodedPath.Length; i++)
+				{
+					_encodedPath[i] = socketAddress[s_nativePathOffset + i];
+				}
+
+				_path = s_pathEncoding.GetString(_encodedPath, 0, _encodedPath.Length);
+			}
+			else
+			{
+				_encodedPath = Array.Empty<byte>();
+				_path = string.Empty;
+			}
+		}
+
+		public override SocketAddress Serialize()
+		{
+			var result = new SocketAddress(AddressFamily.Unix, s_nativeAddressSize);
+			Debug.Assert(_encodedPath.Length + s_nativePathOffset <= result.Size, "Expected path to fit in address");
+
+			for (int index = 0; index < _encodedPath.Length; index++)
+			{
+				result[s_nativePathOffset + index] = _encodedPath[index];
+			}
+
+			result[s_nativePathOffset + _encodedPath.Length] = 0; // path must be null-terminated
+
+			return result;
+		}
+
+		public override EndPoint Create(SocketAddress socketAddress) => new UnixDomainSocketEndPoint(socketAddress);
+
+		public override AddressFamily AddressFamily => EndPointAddressFamily;
+
+		public override string ToString() => _path;
+	}
+}

--- a/src/Syslog.Framework.Logging/TransportProtocols/UnixSockets/UnixSocketMessageSender.cs
+++ b/src/Syslog.Framework.Logging/TransportProtocols/UnixSockets/UnixSocketMessageSender.cs
@@ -1,0 +1,37 @@
+using System.Net.Sockets;
+
+namespace Syslog.Framework.Logging.TransportProtocols.UnixSockets
+{
+	/// <summary>
+	/// Sends message to a syslog server using local UNIX sockets.
+	/// </summary>
+	/// <remarks>
+	/// Note that depending on syslog server UNIX sockets can expect different message format than other protocols.
+	/// This is the case on rsyslog by default. If you want to use UNIX socket logging using this library you should
+	/// set UseSpecialParser="off" either for default /dev/log socket or add new socket with this special parser disabled.
+	/// Example configuration for /dev/log in rsyslog.conf:
+	/// <example>
+	///    module(load="imuxsock" SysSock.UseSpecialParser="off")
+	/// </example>
+	/// </remarks>
+	public class UnixSocketMessageSender : IMessageSender
+	{
+		private readonly string _socketPath;
+
+		public UnixSocketMessageSender(string socketPath)
+		{
+			_socketPath = socketPath;
+		}
+
+		public void SendMessageToServer(byte[] messageData)
+		{
+			using(var socket = new Socket(AddressFamily.Unix, SocketType.Dgram, ProtocolType.IP))
+			{
+				var endpoint = new UnixDomainSocketEndPoint(_socketPath);
+				socket.Connect(endpoint);
+
+				socket.Send(messageData);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pull requests adds the support for sending of log messages by UNIX domain sockets.

The user can choose whether he wants to use UDP or UNIX sockets. The default transport protocol is UDP to maintain backward compatibility (a user which upgrades to a new version of the library and recompiles his code will not see any changes in logging behavior unless he explicitly enables UNIX sockets).

Also to make adding of new transport protocols easier I have made the sending of messages extensible. A developer using the library can implement his own transport protocol and tell the library to use it to send messages just by assigning a single field). More in the updated README.

Why would you use UNIX sockets as opposed to UDP?
- it is the standard way to log on linux, most linux app logs to a syslog by the UNIX domain sockets, whether directly or by syslog system call. It is enabled by default in most linux syslog servers (although the expected message format has to be changed in server configuration),
- reliable (while still faster than TCP), UDP is unreliable even when sending messages on localhost (https://stackoverflow.com/questions/2128701/is-sending-data-via-udp-sockets-on-the-same-machine-reliable)
- if you really need this, a flow control can be used - you can enable blocking of logging as opposed to discarding of messages when syslog server cannot keep up with log processing.

As far as I know UNIX sockets have the following drawbacks:
- not available on Windows,
- local only - cannot be used for sending to a remote server. This is not really an drawback when using advanced syslog implementation such as rsyslog, as rsyslog can be configured to forward the message using UDP or TCP to another server while also saving the logs locally + queueing them if remote server is temporarily offline (as opposed to losing the messages as is in the case of UDP).

During the implementation of UnixSocketMessageSender I have tumbled upon an problem. It seems a [UnixDomainSocketEndPoint class](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.unixdomainsocketendpoint)  is not available in .NET Standard (while available in .NET Core 2.1). For now I have copied the simplified implementation from .NET Core sources as was recommended in (https://github.com/dotnet/corefx/issues/10981#issuecomment-241093852).
This should not be the problem as the .NET Core has the same license as this library. When UnixDomainSocketEndPoint comes to a .NET Standard we should be able to just ditch the copied implementation and use the one from .NET without any other changes.

Tested on:
- Xubuntu 16.04, rsyslog 8.16.0,
- Raspbian Stretch, rsyslog 8.24.0